### PR TITLE
Type Casts && Mutators

### DIFF
--- a/compiler/compiler.py
+++ b/compiler/compiler.py
@@ -3,31 +3,45 @@
 #
 
 MINERVA_PREFIX = "minerva_";
-
-def __type_to_minerva(t):
+SKIP_TYPES = ["short", "long"]
+ALWAYS_SKIP_TYPES = ["const","unsigned", "signed"]
+def __type_to_minerva(t,unify_types = 1):
     r = "__minerva_"
 
     while t[0] is not None:
         r += t[0] + "_"
         t = t[1]
     r += t[1]
+    
     r = r.replace("*","ptr")
-
+    
+    for type in ALWAYS_SKIP_TYPES:
+        r = r.replace(type + "_","")
+    
+    if unify_types == 1:
+        for type in SKIP_TYPES:
+            r = r.replace(type + "_","")
     return r + "_t"
 
-def __type_to_str(t):
+def __type_to_str(t, unify_types = 1):
     r = ""
 
     while t[0] is not None:
         r += t[0] + " "
         t = t[1]
     r += t[1]
-
+    
+    for type in ALWAYS_SKIP_TYPES:
+        r = r.replace(type + " ","")
+    
+    if unify_types == 1:
+        for type in SKIP_TYPES:
+            r = r.replace(type + " ","")
     return r
 
 def __compile_type_enum(types):
     r = "typedef enum {\n"
-    r += ",\n".join(set(map(lambda x: "\t"+__type_to_minerva(x), types)))
+    r += ",\n".join(set(map(lambda x: "\t"+__type_to_minerva(x,0), types)))
     r += "\n\t,__minerva_types_no"
     r += "\n} minerva_type_t;\n"
     
@@ -35,7 +49,7 @@ def __compile_type_enum(types):
 
 def __compile_type_name(types):
     r = "const char *minerva_type_name[] = {\n"
-    r += ",\n".join(map(lambda x: "\t\""+__type_to_str(x)+"\"", types))
+    r += ",\n".join(set(map(lambda x: "\t\""+__type_to_str(x,0)+"\"", types)))
     r += "\n};\n"
     
     return r
@@ -53,10 +67,11 @@ def __compile_wrapper(funcs):
         for i, a in enumerate(args):
             a = a[0]
             r += "\t"+__type_to_str(a)+" "+"__arg"+str(i)+" = "
+            r += "(" + __type_to_str(a) +") "
             if '*' in __type_to_str(a):
-                r += "("+__type_to_str(a)+")vars["+str(i)+"]->val;\n"
+                r += "vars["+str(i)+"]->val;\n"
             else:
-                r += "*("+__type_to_str(a)+"*)vars["+str(i)+"]->val;\n"
+                r += "*("+__type_to_str(a,0)+"*)vars["+str(i)+"]->val;\n"
         if f[1][1] == 'void':
                 r += "\t"+f[2]+"("+",".join(["__arg"+str(i) for i in range(len(args))])+");"
         else:
@@ -64,9 +79,9 @@ def __compile_wrapper(funcs):
                 r += "\tnew->val = " + \
                   f[2]+"("+",".join(["__arg"+str(i) for i in range(len(args))])+");"
             else: 
-                r += "\tnew->val = xcalloc(1,sizeof("+__type_to_str(f[1])+"));\n"
+                r += "\tnew->val = xcalloc(1,sizeof("+__type_to_str(f[1],0)+"));\n"
                 r += "\tnew->flags |= F_VAR_ALLOC;\n"
-                r += "\t*(("+__type_to_str(f[1])+"*)new->val) = ("+__type_to_str(f[1])+")"+\
+                r += "\t*(("+__type_to_str(f[1],0)+"*)new->val) = ("+__type_to_str(f[1],0)+")"+\
                   f[2]+"("+",".join(["__arg"+str(i) for i in range(len(args))])+");"
      
         r += "\n\treturn 1;\n}\n\n"

--- a/core/minerva_generic.c
+++ b/core/minerva_generic.c
@@ -79,3 +79,19 @@ mutate_int_and(int a, int b)
 
 MUTATE_TYPE_BITFLIP(int)
 MUTATE_TYPE_BITFLIP(char)
+
+/* CASTS */
+/* God, have mercy on him */
+#define CAST_TYPE(from_type,to_type) \
+    to_type from_type##_to_##to_type(from_type x) \
+    { \
+        return (to_type) x; \
+    }
+CAST_TYPE(int,char)
+CAST_TYPE(char,int)
+CAST_TYPE(long long, int)
+CAST_TYPE(int, long long)
+CAST_TYPE(long, int)
+CAST_TYPE(int, long)
+CAST_TYPE(float,double)
+CAST_TYPE(double,float)

--- a/core/minerva_generic.c
+++ b/core/minerva_generic.c
@@ -79,6 +79,8 @@ mutate_int_and(int a, int b)
 
 MUTATE_TYPE_BITFLIP(int)
 MUTATE_TYPE_BITFLIP(char)
+MUTATE_TYPE_BITFLIP(long)
+MUTATE_TYPE_BITFLIP(float)
 
 /* CASTS */
 /* God, have mercy on him */
@@ -89,9 +91,9 @@ MUTATE_TYPE_BITFLIP(char)
     }
 CAST_TYPE(int,char)
 CAST_TYPE(char,int)
-CAST_TYPE(long long, int)
-CAST_TYPE(int, long long)
 CAST_TYPE(long, int)
 CAST_TYPE(int, long)
 CAST_TYPE(float,double)
 CAST_TYPE(double,float)
+CAST_TYPE(int,float)
+CAST_TYPE(float,int)

--- a/core/minerva_generic.c
+++ b/core/minerva_generic.c
@@ -80,7 +80,6 @@ mutate_int_and(int a, int b)
 MUTATE_TYPE_BITFLIP(int)
 MUTATE_TYPE_BITFLIP(char)
 MUTATE_TYPE_BITFLIP(long)
-MUTATE_TYPE_BITFLIP(float)
 
 /* CASTS */
 /* God, have mercy on him */

--- a/include/minerva_generic.h
+++ b/include/minerva_generic.h
@@ -39,14 +39,14 @@ MUTATE_TYPE_BITFLIP_PROTO(char);
 MUTATE_TYPE_BITFLIP_PROTO(long);
 
 /* God, have mercy on him */
-#define CAST_TYPE_PROTO(from_type, to_type)  to_type from_type##_to_##to_type(from_type x)
-CAST_TYPE_PROTO(int,char)
-CAST_TYPE_PROTO(char,int)
-CAST_TYPE_PROTO(long, int)
-CAST_TYPE_PROTO(int, long)
-CAST_TYPE_PROTO(float,double)
-CAST_TYPE_PROTO(double,float)
-CAST_TYPE_PROTO(int,float)
-CAST_TYPE_PROTO(float,int)
+#define CAST_TYPE_PROTO(from_type, to_type) to_type from_type##_to_##to_type(from_type x)
+CAST_TYPE_PROTO(int,char);
+CAST_TYPE_PROTO(char,int);
+CAST_TYPE_PROTO(long, int);
+CAST_TYPE_PROTO(int, long);
+CAST_TYPE_PROTO(float,double);
+CAST_TYPE_PROTO(double,float);
+CAST_TYPE_PROTO(int,float);
+CAST_TYPE_PROTO(float,int);
 
 #endif /* ! _MINERVA_GENERIC_H_ */

--- a/include/minerva_generic.h
+++ b/include/minerva_generic.h
@@ -36,5 +36,17 @@ int mutate_int_and(int, int );
 #define MUTATE_TYPE_BITFLIP_PROTO(type) type mutate_##type##_bitflip(type)
 MUTATE_TYPE_BITFLIP_PROTO(int);
 MUTATE_TYPE_BITFLIP_PROTO(char);
+MUTATE_TYPE_BITFLIP_PROTO(long);
+
+/* God, have mercy on him */
+#define CAST_TYPE_PROTO(from_type, to_type)  to_type from_type##_to_##to_type(from_type x)
+CAST_TYPE_PROTO(int,char)
+CAST_TYPE_PROTO(char,int)
+CAST_TYPE_PROTO(long, int)
+CAST_TYPE_PROTO(int, long)
+CAST_TYPE_PROTO(float,double)
+CAST_TYPE_PROTO(double,float)
+CAST_TYPE_PROTO(int,float)
+CAST_TYPE_PROTO(float,int)
 
 #endif /* ! _MINERVA_GENERIC_H_ */

--- a/target/generic/Makefile
+++ b/target/generic/Makefile
@@ -1,0 +1,4 @@
+TARGET=generic
+LOCAL_SRC= 
+
+include ../../mk/minerva.mk

--- a/target/generic/cast.mi
+++ b/target/generic/cast.mi
@@ -1,10 +1,15 @@
 #include <minerva_generic.h>
-
-char    int_to_char     (int)    => generic_success;
-int     char_to_int     (char)   => generic_success;
-int     long_to_int     (long)   => generic_success;
-long    int_to_long     (int)    => generic_success;
-double  float_to_double (float)  => generic_success;
-float   double_to_float (double) => generic_success;
-int     float_to_int    (float)  => generic_success;
-float   int_to_float    (int)    => generic_success;
+--mutators
+int     mutate_int_bitflip  (int)    => generic_success;
+char    mutate_char_bitflip (char)   => generic_success;
+long    mutate_long_bitflip (long)   => generic_success;
+float   mutate_float_bitflip(float)  => generic_success;    
+--casts
+char    int_to_char         (int)    => generic_success;
+int     char_to_int         (char)   => generic_success;
+int     long_to_int         (long)   => generic_success;
+long    int_to_long         (int)    => generic_success;
+double  float_to_double     (float)  => generic_success;
+float   double_to_float     (double) => generic_success;
+int     float_to_int        (float)  => generic_success;
+float   int_to_float        (int)    => generic_success;

--- a/target/generic/cast.mi
+++ b/target/generic/cast.mi
@@ -1,9 +1,4 @@
-#include <minerva_generic.h>
---mutators
-int     mutate_int_bitflip  (int)    => generic_success;
-char    mutate_char_bitflip (char)   => generic_success;
-long    mutate_long_bitflip (long)   => generic_success;
-float   mutate_float_bitflip(float)  => generic_success;    
+#include <minerva_generic.h>   
 --casts
 char    int_to_char         (int)    => generic_success;
 int     char_to_int         (char)   => generic_success;

--- a/target/generic/cast.mi
+++ b/target/generic/cast.mi
@@ -1,0 +1,10 @@
+#include <minerva_generic.h>
+
+char    int_to_char     (int)    => generic_success;
+int     char_to_int     (char)   => generic_success;
+int     long_to_int     (long)   => generic_success;
+long    int_to_long     (int)    => generic_success;
+double  float_to_double (float)  => generic_success;
+float   double_to_float (double) => generic_success;
+int     float_to_int    (float)  => generic_success;
+float   int_to_float    (int)    => generic_success;

--- a/target/generic/mutate.mi
+++ b/target/generic/mutate.mi
@@ -1,0 +1,9 @@
+#include <minerva_generic.h>
+--mutators
+int     mutate_int_bitflip  (int)       => generic_success;
+char    mutate_char_bitflip (char)      => generic_success;
+long    mutate_long_bitflip (long)      => generic_success;
+float   mutate_float_bitflip(float)     => generic_success;    
+int     mutate_int_xor      (int, int)  => generic_success;
+int     mutate_int_or       (int, int)  => generic_success;
+int     mutate_int_and      (int, int)  => generic_success;

--- a/target/generic/mutate.mi
+++ b/target/generic/mutate.mi
@@ -3,7 +3,7 @@
 int     mutate_int_bitflip  (int)       => generic_success;
 char    mutate_char_bitflip (char)      => generic_success;
 long    mutate_long_bitflip (long)      => generic_success;
-float   mutate_float_bitflip(float)     => generic_success;    
+   
 int     mutate_int_xor      (int, int)  => generic_success;
 int     mutate_int_or       (int, int)  => generic_success;
 int     mutate_int_and      (int, int)  => generic_success;


### PR DESCRIPTION
-> whenever a function needs unsigned/signed/short/long type the wrapper takes just the type casts it to the original one than. Function's types are casted  (generate any target.c to see how it works).
example:
short int func(short int)
int func_wrapper(int)
-> added new target  - generic
      \*  more casts
      \*  mutators
